### PR TITLE
[feat] 메인 학습 뷰 기본 UI 구현

### DIFF
--- a/Projects/Medimo/Sources/Study/View/StudyView.swift
+++ b/Projects/Medimo/Sources/Study/View/StudyView.swift
@@ -9,31 +9,36 @@ import SwiftUI
 
 struct StudyView: View {
     @EnvironmentObject var navigationManager: NavigationManager
-    var viewModel: StudyViewModel
+    @Bindable var viewModel: StudyViewModel
+    @Bindable var studyManager = StudyManager.shared
+    
+    @State private var isAtTop: Bool = true
 
     init(glossary: Glossary) {
         viewModel = .init(studyingGlossary: glossary)
     }
 
     var body: some View {
-        ScrollView {
-            StudyHeaderView(streak: viewModel.streak)
-                .padding(.horizontal, 24)
-                .padding(.top, 48)
-            
-            Button {
-                navigationManager.push(to: .StudyCard(glossary: viewModel.studyingGlossary))
-            } label: {
-                Text("Study")
-                    .font(.headline)
-                    .fontWeight(.bold)
-                    .foregroundColor(.white)
-                    .padding()
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color.blue)
+        ZStack {
+            ScrollView {
+                VStack(spacing: 0) {
+                    StudyHeaderView(streak: viewModel.streak)
+                    StudyMainCardView(
+                        studyingGlossary: $viewModel.studyingGlossary,
+                        studyTermSize: $studyManager.studyTermSize
                     )
+                    .padding(.top, 42)
+                    .padding(.horizontal, 16)
+                    StudyCalendarCardView()
+                        .padding(16)
+                }
+                .background(
+                    StudyHeaderBackgroundView()
+                )
             }
+            .scrollIndicators(.hidden)
+            .ignoresSafeArea(edges: .top)
+            .background(AppColor.systemGroupedBackground)
         }
     }
 }

--- a/Projects/Medimo/Sources/Study/View/StudyView.swift
+++ b/Projects/Medimo/Sources/Study/View/StudyView.swift
@@ -16,18 +16,24 @@ struct StudyView: View {
     }
 
     var body: some View {
-        Button {
-            navigationManager.push(to: .StudyCard(glossary: viewModel.studyingGlossary))
-        } label: {
-            Text("Study")
-                .font(.headline)
-                .fontWeight(.bold)
-                .foregroundColor(.white)
-                .padding()
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(Color.blue)
-                )
+        ScrollView {
+            StudyHeaderView(streak: viewModel.streak)
+                .padding(.horizontal, 24)
+                .padding(.top, 48)
+            
+            Button {
+                navigationManager.push(to: .StudyCard(glossary: viewModel.studyingGlossary))
+            } label: {
+                Text("Study")
+                    .font(.headline)
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.blue)
+                    )
+            }
         }
     }
 }

--- a/Projects/Medimo/Sources/Study/View/SubView/ReviewStartButtonView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/ReviewStartButtonView.swift
@@ -1,0 +1,51 @@
+//
+//  ReviewStartButtonView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/4/25.
+//
+
+import SwiftUI
+
+struct ReviewStartButtonView: View {
+    var action: () -> Void = {}
+    
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                HStack {
+                    Spacer()
+                    Image("cloudImage")
+                        .resizable()
+                        .scaledToFill()
+                        .rotationEffect(Angle(degrees: -30))
+                        .frame(width: 186, height: 60)
+                        .offset(x: 30, y: 18)
+                        .clipped()
+                }
+                HStack {
+                    Text("복습하기")
+                        .font(.headline)
+                        .foregroundStyle(AppColor.primaryPink)
+                        .padding(.leading, 16)
+                    Spacer()
+                }
+            }
+            .background(AppColor.white)
+            .mask(
+                RoundedRectangle(cornerRadius: 16)
+                    .frame(height: 60)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .inset(by: 1)
+                    .stroke(AppColor.pink, lineWidth: 2)
+                    .frame(height: 60)
+            )
+        }
+    }
+}
+
+#Preview {
+    ReviewStartButtonView(action: {})
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyCalendarCardView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyCalendarCardView.swift
@@ -1,0 +1,46 @@
+//
+//  StudyCalendarCardView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/5/25.
+//
+
+import SwiftUI
+
+struct StudyCalendarCardView: View {
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 28)
+                .fill(AppColor.white.opacity(0.9))
+                .shadow(
+                    color: Color(
+                        uiColor: UIColor(
+                            red: 164/255,
+                            green: 193/255,
+                            blue: 247/255,
+                            alpha: 0.45
+                        )
+                    ),
+                    radius: 10, x: 0, y: 2
+                )
+            VStack {
+                HStack {
+                    Text("나의 학습 캘린더")
+                        .font(.body)
+                    Spacer()
+                    Image("chevron-right")
+                        .resizable()
+                        .frame(width: 21, height: 21)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 26)
+        }
+    }
+}
+
+#Preview {
+    ScrollView {
+        StudyCalendarCardView()
+    }
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyHeaderBackgroundView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyHeaderBackgroundView.swift
@@ -1,0 +1,34 @@
+//
+//  StudyHeaderBackgroundView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/5/25.
+//
+
+import SwiftUI
+
+struct StudyHeaderBackgroundView: View {
+    var body: some View {
+        VStack {
+            LinearGradient(
+                colors: [
+                    Color(UIColor(red: 187/255, green: 209/255, blue: 249/255, alpha: CGFloat(1))),
+                    Color(UIColor(red: 187/255, green: 209/255, blue: 249/255, alpha: CGFloat(0)))
+                ],
+                startPoint: UnitPoint(x: 0.5, y: 0.65),
+                endPoint: UnitPoint(x: 0.5, y: 1)
+            )
+            .frame(height: 250)
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    ScrollView {
+        VStack {
+            Color.clear
+        }
+        .background(StudyHeaderBackgroundView())
+    }
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyHeaderView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyHeaderView.swift
@@ -13,7 +13,7 @@ struct StudyHeaderView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Text("\(streak)일 째")
+                Text("\(streak)일째")
                     .font(.largeTitle)
                     .foregroundStyle(AppColor.label)
                 Spacer()
@@ -25,11 +25,15 @@ struct StudyHeaderView: View {
                 Spacer()
             }
         }
-        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 24)
+        .padding(.top, 82)
     }
 }
 
 #Preview {
     var streak: Int = 5
-    StudyHeaderView(streak: streak)
+    ScrollView {
+        StudyHeaderView(streak: streak)
+    }
+    .ignoresSafeArea(edges: .top)
 }

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyHeaderView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyHeaderView.swift
@@ -1,0 +1,35 @@
+//
+//  StudyHeaderView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/4/25.
+//
+
+import SwiftUI
+
+struct StudyHeaderView: View {
+    @State var streak: Int
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("\(streak)일 째")
+                    .font(.largeTitle)
+                    .foregroundStyle(AppColor.label)
+                Spacer()
+            }
+            HStack {
+                Text("학습중이에요! 화이팅!! 🎉")
+                    .font(.title)
+                    .foregroundStyle(AppColor.label)
+                Spacer()
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+#Preview {
+    var streak: Int = 5
+    StudyHeaderView(streak: streak)
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyMainCardBackgroundView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyMainCardBackgroundView.swift
@@ -1,0 +1,47 @@
+//
+//  StudyMainCardBackgroundView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/4/25.
+//
+
+import SwiftUI
+
+struct StudyMainCardBackgroundView: View {
+    var body: some View {
+        RoundedRectangle(cornerRadius: 28)
+            .inset(by: 2)
+            .fill(AppColor.white.opacity(0.3))
+            .stroke(
+                LinearGradient(
+                    gradient: Gradient(
+                        colors: [
+                            AppColor.skyPink,
+                            AppColor.skyBlue
+                        ]
+                    ),
+                    startPoint: .topLeading, endPoint: .bottomTrailing
+                ),
+                lineWidth: 4
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 28)
+                    .inset(by: 4)
+                    .fill(
+                        LinearGradient(
+                            gradient: Gradient(
+                                colors: [
+                                    AppColor.white.opacity(0.2),
+                                    AppColor.white.opacity(0)
+                                ]
+                            ),
+                            startPoint: .topTrailing, endPoint: .bottomLeading
+                        )
+                    )
+            )
+    }
+}
+
+#Preview {
+    StudyMainCardBackgroundView()
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyMainCardView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyMainCardView.swift
@@ -1,0 +1,56 @@
+//
+//  StudyMainCardView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/4/25.
+//
+
+import SwiftUI
+
+struct StudyMainCardView: View {
+    @EnvironmentObject var navigationManager: NavigationManager
+    
+    @Binding var studyingGlossary: Glossary
+    @Binding var studyTermSize: Int
+    
+    var body: some View {
+        ZStack {
+            StudyMainCardBackgroundView()
+            VStack {
+                HStack {
+                    StudyingGloassaryChooseButtonView()
+                    Spacer()
+                    StudyTermSizeChooseButtonView()
+                }
+                StudyRingView()
+                    .padding(.top, 28)
+                    .padding(.bottom, 32)
+                VStack(spacing: 16) {
+                    StudyStartButtonView(action: {
+                        navigationManager.push(to: .StudyCard(glossary: studyingGlossary))
+                    })
+                        .padding(.horizontal, 20)
+                    ReviewStartButtonView()
+                        .padding(.horizontal, 20)
+                }
+            }
+            .padding(.horizontal, 30)
+            .padding(.top, 42)
+            .padding(.bottom, 36)
+        }
+    }
+}
+
+#Preview {
+    let context = PersistenceController.preview.container.viewContext
+    var glossary = try! context.fetch(Glossary.fetchRequest())[0]
+    @Bindable var viewModel = StudyViewModel(studyingGlossary: glossary)
+    @Bindable var studyManager = StudyManager.shared
+    ScrollView {
+        StudyMainCardView(
+            studyingGlossary: $viewModel.studyingGlossary,
+            studyTermSize: $studyManager.studyTermSize
+        )
+            .padding(16)
+    }
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyRingView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyRingView.swift
@@ -1,0 +1,68 @@
+//
+//  StudyRingView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/4/25.
+//
+
+import SwiftUI
+
+struct StudyRingView: View {
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        gradient: Gradient(colors: [AppColor.skyPink, AppColor.skyBlue]),
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .rotationEffect(.degrees(30))
+                .frame(width: 250, height: 250)
+                .overlay(
+                    VStack {
+                        HStack(alignment: .bottom, spacing: 4) {
+                            Text("240")
+                                .font(.custom("Gmarket Sans Bold", size: 48))
+                                .foregroundStyle(AppColor.label)
+                            Text("/300")
+                                .font(.custom("Gmarket Sans Medium", size: 16))
+                                .foregroundStyle(AppColor.label)
+                                .padding(.bottom, 8)
+                        }
+                        Text("나의 학습 현황")
+                            .font(.caption)
+                            .foregroundStyle(AppColor.label)
+                    }
+                )
+            Circle()
+                .trim(from: 0.0, to: 240/300)
+                .stroke(
+                    LinearGradient(
+                        gradient: Gradient(colors: [AppColor.navy, AppColor.blue]),
+                        startPoint: UnitPoint(x: 0.7, y: 0.7),
+                        endPoint: UnitPoint(x: -0.7, y: -0.7)
+                    ),
+                    style: StrokeStyle(lineWidth: 40, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .frame(width: 250, height: 250)
+                .background(
+                    Circle()
+                        .trim(from: 0.0, to: 240/300)
+                        .stroke(
+                            AppColor.white,
+                            style: StrokeStyle(lineWidth: 41, lineCap: .round)
+                        )
+                        .rotationEffect(.degrees(-90))
+                        .frame(width: 250, height: 250)
+                        .shadow(color: AppColor.textColor.opacity(0.3), radius: 5, x: 2, y: 4)
+                )
+        }
+    }
+}
+
+#Preview {
+    StudyRingView()
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyStartButtonView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyStartButtonView.swift
@@ -1,0 +1,51 @@
+//
+//  StudyStartButtonView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/4/25.
+//
+
+import SwiftUI
+
+struct StudyStartButtonView: View {
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                HStack {
+                    Spacer()
+                    Image("character1")
+                        .resizable()
+                        .scaledToFill()
+                        .rotationEffect(Angle(degrees: -30))
+                        .offset(x: 30, y: 8)
+                        .frame(width: 136, height: 60)
+                        .clipped()
+                }
+                HStack {
+                    Text("학습하기")
+                        .font(.headline)
+                        .foregroundStyle(AppColor.primary)
+                        .padding(.leading, 16)
+                    Spacer()
+                }
+            }
+            .background(AppColor.white)
+            .mask(
+                RoundedRectangle(cornerRadius: 16)
+                    .frame(height: 60)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .inset(by: 1)
+                    .stroke(AppColor.blue, lineWidth: 2)
+                    .frame(height: 60)
+            )
+        }
+    }
+}
+
+#Preview {
+    StudyStartButtonView(action: {})
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyTermSizeChooseButtonView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyTermSizeChooseButtonView.swift
@@ -1,0 +1,42 @@
+//
+//  StudyTermSizeChooseButtonView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/4/25.
+//
+
+import SwiftUI
+
+struct StudyTermSizeChooseButtonView: View {
+    var body: some View {
+        Button {
+            
+        } label: {
+            HStack(spacing: 10) {
+                Text("하루 목표: ")
+                    .font(.caption)
+                    .foregroundStyle(AppColor.secondaryLabel)
+                HStack(spacing: 6) {
+                    Text("30개")
+                        .font(.caption)
+                        .foregroundStyle(AppColor.primary)
+                    Image("chevron-down")
+                        .resizable()
+                        .frame(width: 12, height: 12)
+                        .foregroundStyle(AppColor.primary)
+                }
+            }
+            .padding(.vertical, 4)
+            .overlay(
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundColor(AppColor.grey3),
+                alignment: .bottom
+            )
+        }
+    }
+}
+
+#Preview {
+    StudyTermSizeChooseButtonView()
+}

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyingGloassaryChooseButtonView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyingGloassaryChooseButtonView.swift
@@ -1,0 +1,29 @@
+//
+//  StudyingGloassaryChooseButtonView.swift
+//  Projects
+//
+//  Created by 양시준 on 6/4/25.
+//
+
+import SwiftUI
+
+struct StudyingGloassaryChooseButtonView: View {
+    var body: some View {
+        Button {
+        
+        } label: {
+            HStack(spacing: 16) {
+                Text("신경외과")
+                    .font(.title)
+                    .foregroundStyle(AppColor.label)
+                Image("chevron-down")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+            }
+        }
+    }
+}
+
+#Preview {
+    StudyingGloassaryChooseButtonView()
+}

--- a/Projects/Medimo/Sources/Study/ViewModel/StudyViewModel.swift
+++ b/Projects/Medimo/Sources/Study/ViewModel/StudyViewModel.swift
@@ -11,6 +11,9 @@ import Foundation
 class StudyViewModel {
     var studyingGlossary: Glossary
     
+    // TODO: 연속 학습일 처리
+    var streak: Int = 0
+    
     init(studyingGlossary: Glossary) {
         self.studyingGlossary = studyingGlossary
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 작업 요약)
예시: [Feat] 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #47 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- StudyView와 서브뷰 구현

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

| ![Screenshot 2025-06-05 at 4 27 13 AM](https://github.com/user-attachments/assets/698a1a3e-1624-4139-bae3-1efb3d300f1a) | ![Screenshot 2025-06-05 at 4 27 16 AM](https://github.com/user-attachments/assets/8aea2a5e-c295-4cf9-9e23-6b4156f5a894) |
|---|---|


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 학습하기 버튼 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 캘린더 뷰는 추후 구현되면 이용하여 반영 예정
- 스크롤 시 상단 SafeArea에 반투명 블러 효과 넣을 예정
- 학습하기 버튼 외 다른 버튼 액션, 모달 등 구현 안 되
- 학습하는 뷰에서 뒤로 가면 앱 중단 되는 에러 발견

---
