### PR TITLE
[Fix] terms 로드 이슈 해결

### DIFF
--- a/Projects/Medimo/Sources/Data/Loader/InitialDataLoader.swift
+++ b/Projects/Medimo/Sources/Data/Loader/InitialDataLoader.swift
@@ -25,7 +25,11 @@ class InitialDataLoader {
         try linkGlossaryToTerm()
         try linkTermToMorpheme()
         
-        makeTermLearningMetadata()
+        let request: NSFetchRequest<TermLearningMetadata> = TermLearningMetadata.fetchRequest()
+        let count = try? context.count(for: request)
+        if count == 0 {
+            makeTermLearningMetadata()
+        }
     }
     
     private func loadGlossaries() throws {
@@ -97,6 +101,8 @@ class InitialDataLoader {
                 termLearningMetadata.repetitions = 0
             }
         }
+        
+        try? context.save()
     }
     
     private func loadJsonData<T: Decodable>(_ filename: String) throws -> [T] {

--- a/Projects/Medimo/Sources/Shared/StudyManager.swift
+++ b/Projects/Medimo/Sources/Shared/StudyManager.swift
@@ -91,7 +91,7 @@ public class StudyManager {
         var result: [Term] = []
         for termId in termIdList {
             guard let term = studyingGlossary?.termsArray.first(where: { $0.id == termId }) else { continue }
-            termLearnMetadataList!.first(where: { $0.id == term.id })?.status = LearningStatus.inProgress.rawValue
+            termLearnMetadataList!.first(where: { $0.termId == term.id })?.status = LearningStatus.inProgress.rawValue
             result.append(term)
             if result.count >= studyTermSize { break }
         }
@@ -102,7 +102,7 @@ public class StudyManager {
     func updateReview(of term: Term, result: QuizResult) {
         let now = Date()
         
-        let meta = termLearnMetadataList!.first(where: { $0.id == term.id })!
+        let meta = termLearnMetadataList!.first(where: { $0.termId == term.id })!
         meta.status = LearningStatus.completed.rawValue
         
         switch result {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 작업 요약)
예시: [Feat] 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #102 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `InitialDataLoader`에서 `makeTermLearningMetadata()`에 try? context.save() 추가
- `InitialDataLoader`에서 `makeTermLearningMetadata()`은 DB에 `TermLearningMetadata`가 하나도 없을 때만 실행되도록 설정 (첫 설정만 할 수 있도록)
- `StudyManager`에서 `termLearnMetadataList`에서 term들 가져올 때 `id`랑 `term.id` 비교가 아니라 `termId`랑 `term.id` 비교하여 가져올 수 있도록 수정

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->