### PR TITLE
[Feat] 캘린더 학습 진행도 달력에 넣기

### DIFF
--- a/Projects/Medimo/Resources/CoreData/MedimoModel.xcdatamodeld/MedimoModel.xcdatamodel/contents
+++ b/Projects/Medimo/Resources/CoreData/MedimoModel.xcdatamodeld/MedimoModel.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="reviewCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="studyCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
-        <relationship name="totalStudyHist" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="totalStudyHist" inverseEntity="User"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="dateInfos" inverseEntity="User"/>
     </entity>
     <entity name="Glossary" representedClassName=".Glossary" syncable="YES" codeGenerationType="class">
         <attribute name="category" optional="YES" attributeType="String"/>
@@ -61,9 +61,9 @@
         <attribute name="longestStreak" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="totalLearningTerms" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="bookmarks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Term" inverseName="bookmarks" inverseEntity="Term"/>
+        <relationship name="dateInfos" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DateInfo" inverseName="user" inverseEntity="DateInfo"/>
         <relationship name="progresses" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="GlossaryProgress" inverseName="user" inverseEntity="GlossaryProgress"/>
         <relationship name="termStudyData" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TermStudyData" inverseName="user" inverseEntity="TermStudyData"/>
-        <relationship name="totalStudyHist" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DateInfo" inverseName="totalStudyHist" inverseEntity="DateInfo"/>
     </entity>
     <configuration name="Global"/>
     <configuration name="Personal">

--- a/Projects/Medimo/Sources/Shared/CoreDataManager.swift
+++ b/Projects/Medimo/Sources/Shared/CoreDataManager.swift
@@ -15,7 +15,7 @@ final class CoreDataManager {
     let context: NSManagedObjectContext
 
     private init(inMemory: Bool = false) {
-        container = NSPersistentCloudKitContainer(name: "MedimoModel")
+        container = NSPersistentContainer(name: "MedimoModel")
         if inMemory {
             container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
         }
@@ -255,6 +255,23 @@ extension CoreDataManager {
         user.currentStreak = 0
         user.longestStreak = 0
         user.totalLearningTerms = 0
+
+        // TODO: - 나중에 삭제하기
+        // 테스트용 DateInfo 5개 생성
+        for i in 0 ..< 5 {
+            let dateInfo = DateInfo(context: context)
+            if i % 2 == 0 {
+                dateInfo.date = Calendar.current.date(byAdding: .day, value: -i, to: Date())
+                dateInfo.studyCount = Int32(10 + i)
+                dateInfo.reviewCount = Int32(10 + i)
+            } else {
+                dateInfo.date = Calendar.current.date(byAdding: .day, value: -i, to: Date())
+                dateInfo.studyCount = Int32(10 + i)
+                dateInfo.reviewCount = 0
+            }
+
+            user.addToDateInfos(dateInfo)
+        }
 
         save()
     }

--- a/Projects/Medimo/Sources/Study/View/StudyView.swift
+++ b/Projects/Medimo/Sources/Study/View/StudyView.swift
@@ -34,7 +34,6 @@ struct StudyView: View {
 
                     StudyCalendarCardView(calendarViewModel: calendarViewModel)
                         .onTapGesture {
-                            print("TAP")
                             navigationManager.studyPath.append(.StudyCalendar)
                         }
                         .padding(16)

--- a/Projects/Medimo/Sources/Study/View/SubView/StudyCalendarCardView.swift
+++ b/Projects/Medimo/Sources/Study/View/SubView/StudyCalendarCardView.swift
@@ -5,11 +5,12 @@
 //  Created by 양시준 on 6/5/25.
 //
 
+import CoreData
 import SwiftUI
 
 struct StudyCalendarCardView: View {
-    @ObservedObject var calendarViewModel : CalendarViewModel
-    
+    @ObservedObject var calendarViewModel: CalendarViewModel
+
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 28)
@@ -17,9 +18,9 @@ struct StudyCalendarCardView: View {
                 .shadow(
                     color: Color(
                         uiColor: UIColor(
-                            red: 164/255,
-                            green: 193/255,
-                            blue: 247/255,
+                            red: 164 / 255,
+                            green: 193 / 255,
+                            blue: 247 / 255,
                             alpha: 0.45
                         )
                     ),
@@ -37,11 +38,10 @@ struct StudyCalendarCardView: View {
                         .foregroundColor(AppColor.skyBlue)
                 }
                 .padding(.bottom, 30)
-                
+
                 WeekdayHeaderView(isPreview: true)
-                
+
                 PreviewDatesGridView(calendarViewModel: calendarViewModel)
-                
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 26)
@@ -50,19 +50,74 @@ struct StudyCalendarCardView: View {
 }
 
 struct PreviewDatesGridView: View {
+    @Environment(\.managedObjectContext) private var moc
     @ObservedObject var calendarViewModel: CalendarViewModel
 
+    var dateInfos: [DateInfo] {
+        let fetchRequest: NSFetchRequest<User> = User.fetchRequest()
+        let users = (try? moc.fetch(fetchRequest)) ?? []
+
+        if let user = users.first {
+            let array = user.dateInfos!.allObjects as? [DateInfo] ?? []
+            print(array)
+            return array
+        }
+        return []
+    }
+
+    @ViewBuilder
+    private func studiedBackground(for dateValue: DateValue) -> some View {
+        // dateInfo 중 해당 날짜와 같은 것이 있는지 찾기
+        if let dateInfo = dateInfos.first(where: { calendarViewModel.isSameDay(date1: $0.date ?? Date(), date2: dateValue.date) }) {
+            // 둘 다 0이 아니면 파란색, 하나만 0이 아니면 하늘색
+            let bothNonZero = (dateInfo.studyCount > 0) && (dateInfo.reviewCount > 0)
+            let onlyOneNonZero = (dateInfo.studyCount > 0) != (dateInfo.reviewCount > 0)
+            let color = bothNonZero ? AppColor.blue : (onlyOneNonZero ? AppColor.skyBlue : nil)
+            if let color = color {
+                Circle()
+                    .fill(color)
+                    .frame(width: 40, height: 40)
+            } else {
+                Color.clear
+            }
+        }
+    }
+
     private let columns = Array(repeating: GridItem(.flexible()), count: 7)
+
+    private func isSelected(value: DateValue) -> Bool {
+        calendarViewModel.isSameDay(date1: value.date, date2: calendarViewModel.selectedDate)
+    }
 
     var body: some View {
         LazyVGrid(columns: columns, spacing: 30) {
             ForEach(calendarViewModel.extractCurrentWeekDateValues(currentMonth: calendarViewModel.currentMonth)
             ) { dateValue in
                 if dateValue.day != -1 {
-                    DateButton(
-                        calendarViewModel: calendarViewModel,
-                        value: dateValue
+                    ZStack(alignment: .top) {
+                        //                if isSelected {
+                        //                    Circle()
+                        //                        .foregroundStyle(AppColor.label)
+                        //                        .frame(width: 6, height: 6)
+                        //                        .offset(y: -10) // Adjust as needed to position above the text
+                        //                }
+
+                        Text("\(dateValue.day)")
+                            .font(.bodyEng)
+                            .foregroundStyle(isSelected(value: dateValue) ? AppColor.hotPink : AppColor.grey5)
+                    }
+                    .frame(height: 20)
+                    .background(
+                        // 1개 성공시
+                        //                Circle()
+                        //                    .fill(AppColor.skyBlue)
+                        //                    .frame(width: 40, height: 40)
+                        //                    .opacity(isSelected ? 1 : 0)
+
+                        // 2개 성공시
+                        studiedBackground(for: dateValue)
                     )
+
                 } else {
                     Text("\(dateValue.day)").hidden()
                 }

--- a/Projects/Medimo/Sources/StudyCalendar/Component/CustomCalendar.swift
+++ b/Projects/Medimo/Sources/StudyCalendar/Component/CustomCalendar.swift
@@ -5,6 +5,7 @@
 //  Created by 김현기 on 6/6/25.
 //
 
+import CoreData
 import SwiftUI
 
 struct CustomCalendar: View {
@@ -111,6 +112,7 @@ struct DatesGridView: View {
 }
 
 struct DateButton: View {
+    @Environment(\.managedObjectContext) private var moc
     @ObservedObject var calendarViewModel: CalendarViewModel
 
     var value: DateValue
@@ -123,36 +125,49 @@ struct DateButton: View {
         calendarViewModel.isSameDay(date1: value.date, date2: calendarViewModel.selectedDate)
     }
 
+    var dateInfos: [DateInfo] {
+        let fetchRequest: NSFetchRequest<User> = User.fetchRequest()
+        let users = (try? moc.fetch(fetchRequest)) ?? []
+
+        if let user = users.first {
+            let array = user.dateInfos!.allObjects as? [DateInfo] ?? []
+            print(array)
+            return array
+        }
+        return []
+    }
+
+    @ViewBuilder
+    private func studiedBackground(for dateValue: DateValue) -> some View {
+        // dateInfo 중 해당 날짜와 같은 것이 있는지 찾기
+        if let dateInfo = dateInfos.first(where: { calendarViewModel.isSameDay(date1: $0.date ?? Date(), date2: dateValue.date) }) {
+            // 둘 다 0이 아니면 파란색, 하나만 0이 아니면 하늘색
+            let bothNonZero = (dateInfo.studyCount > 0) && (dateInfo.reviewCount > 0)
+            let onlyOneNonZero = (dateInfo.studyCount > 0) != (dateInfo.reviewCount > 0)
+            let color = bothNonZero ? AppColor.blue : (onlyOneNonZero ? AppColor.skyBlue : nil)
+            if let color = color {
+                Circle()
+                    .fill(color)
+                    .frame(width: 40, height: 40)
+            } else {
+                Color.clear
+            }
+        }
+    }
+
     var body: some View {
         Button {
             calendarViewModel.selectedDate = value.date
             print("📝 Selected Day: \(value.day)")
         } label: {
             ZStack(alignment: .top) {
-//                if isSelected {
-//                    Circle()
-//                        .foregroundStyle(AppColor.label)
-//                        .frame(width: 6, height: 6)
-//                        .offset(y: -10) // Adjust as needed to position above the text
-//                }
-
                 Text("\(value.day)")
                     .font(.bodyEng)
                     .foregroundStyle(isSelected ? AppColor.hotPink : AppColor.grey5)
             }
             .frame(height: 20)
             .background(
-                // 1개 성공시
-//                Circle()
-//                    .fill(AppColor.skyBlue)
-//                    .frame(width: 40, height: 40)
-//                    .opacity(isSelected ? 1 : 0)
-
-                // 2개 성공시
-                Circle()
-                    .fill(AppColor.blue)
-                    .frame(width: 40, height: 40)
-                    .opacity(isSelected ? 1 : 0)
+                studiedBackground(for: value)
             )
         }
 //        .disabled(value.date > Date() ? true : false)

--- a/Projects/Medimo/Sources/StudyCalendar/StudyCalendarView.swift
+++ b/Projects/Medimo/Sources/StudyCalendar/StudyCalendarView.swift
@@ -9,11 +9,39 @@ import CoreData
 import SwiftUI
 
 struct StudyCalendarView: View {
+    @Environment(\.managedObjectContext) private var moc
     @EnvironmentObject var navigationManager: NavigationManager
 
     @StateObject private var calendarViewModel = CalendarViewModel()
     let coreDataManager = CoreDataManager.shared
     let cloudKitManager = CloudKitManager.shared
+
+    var user: User {
+        let fetchRequest: NSFetchRequest<User> = User.fetchRequest()
+        let users = (try? moc.fetch(fetchRequest)) ?? []
+
+        return users.first ?? User(context: moc)
+    }
+
+    var dateInfos: [DateInfo] {
+        let fetchRequest: NSFetchRequest<User> = User.fetchRequest()
+        let users = (try? moc.fetch(fetchRequest)) ?? []
+
+        if let user = users.first {
+            let array = user.dateInfos!.allObjects as? [DateInfo] ?? []
+            print(array)
+            return array
+        }
+        return []
+    }
+
+    func getTotalStudyCount() -> Int {
+        dateInfos.reduce(0) { $0 + Int($1.studyCount) }
+    }
+
+    func getTotalReviewCount() -> Int {
+        dateInfos.reduce(0) { $0 + Int($1.reviewCount) }
+    }
 
     var body: some View {
         ZStack {
@@ -43,16 +71,7 @@ struct StudyCalendarView: View {
                         .foregroundStyle(AppColor.navy)
                         .font(.headline)
                     Spacer()
-                    Button {
-                        let fetchRequest: NSFetchRequest<User> = User.fetchRequest()
-                        let users = (try? coreDataManager.context.fetch(fetchRequest)) ?? []
-                        if let user = users.first {
-                            let array = user.dateInfos!.allObjects as? [DateInfo] ?? []
-                            for dateInfo in array {
-                                print("Date: \(dateInfo.date ?? Date()), Count: \(dateInfo.studyCount)")
-                            }
-                        }
-                    } label: {
+                    Button {} label: {
                         Image("download")
                             .foregroundStyle(AppColor.blue)
                     }
@@ -63,7 +82,7 @@ struct StudyCalendarView: View {
                     HStack {
                         Spacer()
                         VStack {
-                            Text("960개")
+                            Text("\(getTotalStudyCount())개")
                                 .font(.title)
                                 .foregroundStyle(AppColor.navy)
                                 .padding(.bottom, 15)
@@ -73,7 +92,7 @@ struct StudyCalendarView: View {
                         }
                         Spacer(minLength: 75)
                         VStack {
-                            Text("18일")
+                            Text("\(user.longestStreak)일")
                                 .font(.title)
                                 .foregroundStyle(AppColor.blue)
                                 .padding(.bottom, 15)
@@ -117,9 +136,9 @@ struct StudyCalendarView: View {
                         }
                         .padding(.horizontal, 16)
 
-                        WordsStatisticsView(description: "학습한 단어", count: 30)
+                        WordsStatisticsView(description: "학습한 단어", count: getTotalStudyCount())
                         Spacer().frame(height: 10)
-                        WordsStatisticsView(description: "복습한 단어", count: 10)
+                        WordsStatisticsView(description: "복습한 단어", count: getTotalReviewCount())
                     }
                     .padding(.horizontal, 16)
 

--- a/Projects/Medimo/Sources/StudyCalendar/StudyCalendarView.swift
+++ b/Projects/Medimo/Sources/StudyCalendar/StudyCalendarView.swift
@@ -5,6 +5,7 @@
 //  Created by 김현기 on 6/6/25.
 //
 
+import CoreData
 import SwiftUI
 
 struct StudyCalendarView: View {
@@ -43,8 +44,13 @@ struct StudyCalendarView: View {
                         .font(.headline)
                     Spacer()
                     Button {
-                        Task {
-                            await cloudKitManager.deleteAllRecordsFromPrivateDatabase()
+                        let fetchRequest: NSFetchRequest<User> = User.fetchRequest()
+                        let users = (try? coreDataManager.context.fetch(fetchRequest)) ?? []
+                        if let user = users.first {
+                            let array = user.dateInfos!.allObjects as? [DateInfo] ?? []
+                            for dateInfo in array {
+                                print("Date: \(dateInfo.date ?? Date()), Count: \(dateInfo.studyCount)")
+                            }
                         }
                     } label: {
                         Image("download")


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 작업 요약)
예시: [Feat] 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- close #136 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 프리뷰캘린더 날짜 이동 못하게하기
- 내부 캘린더뷰 및 프리뷰캘린더에 학습현황 보이게 하기
- 코어데이터 Container iCloud 랑 연결 해제

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
